### PR TITLE
Update bundler version used by iOS Gemfile

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -214,4 +214,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   1.17.2
+   2.6.7


### PR DESCRIPTION
## Summary
- update the `BUNDLED WITH` entry in `ios/Gemfile.lock` to use Bundler 2.6.7 so the pipeline can find the expected version

## Testing
- bundle install


------
https://chatgpt.com/codex/tasks/task_e_690d05a7127083338556d7b1e3c91da0