### PR TITLE
Add default Fastlane team ID fallback

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -4,6 +4,7 @@ require "fileutils"
 PROJECT_ROOT = File.expand_path("..", __dir__)
 XCODEPROJ_PATH = File.join(PROJECT_ROOT, "shaniDms22.xcodeproj")
 XCWORKSPACE_PATH = File.join(PROJECT_ROOT, "shaniDms22.xcworkspace")
+DEFAULT_TEAM_ID = "8KHU9V3DTQ"
 
 # This file contains the fastlane.tools configuration
 # You can find the documentation at https://docs.fastlane.tools
@@ -89,8 +90,31 @@ def configure_signing_for_local
 end
 
 def appfile_team_id
+  env_team_id = ENV.fetch("APPLE_TEAM_ID", ENV["FASTLANE_TEAM_ID"]).to_s.strip
+  return env_team_id unless env_team_id.empty?
+
   team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id).to_s.strip
+  if team_id.empty?
+    appfile_paths = [
+      ENV["FASTLANE_APPFILE_PATH"],
+      File.expand_path("Appfile", __dir__),
+      File.expand_path("../fastlane/Appfile", __dir__)
+    ].compact
+
+    appfile_paths.each do |path|
+      next unless File.exist?(path)
+
+      match = File.read(path).match(/team_id\(["'](?<team_id>.+?)["']\)/)
+      if match && !match[:team_id].to_s.strip.empty?
+        team_id = match[:team_id].strip
+        break
+      end
+    end
+  end
+
+  team_id = DEFAULT_TEAM_ID if team_id.empty?
   UI.user_error!("No team_id configured in Appfile") if team_id.empty?
+  ENV["FASTLANE_TEAM_ID"] ||= team_id
   team_id
 end
 
@@ -112,7 +136,7 @@ def provisioning_profile_setup
 
   update_project_team(
     path: XCODEPROJ_PATH,
-    teamid: CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
+    teamid: team_id
   )
 end
 


### PR DESCRIPTION
## Summary
- introduce a default Apple Developer team ID constant so Fastlane always has credentials available
- allow overriding the team ID via APPLE_TEAM_ID or FASTLANE_TEAM_ID environment variables and reuse it for project updates

## Testing
- not run (fastlane gem is not installed in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de75704a48333b900434e2700610c)