### PR TITLE
Fix Fastlane export profile mapping

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -239,7 +239,7 @@ platform :ios do
       export_method: "app-store",
       export_options: {
         provisioningProfiles: {
-          app_identifier => app_identifier + " AppStore"
+          app_identifier => profile_name
         }
       },
       build_path: "./builds",


### PR DESCRIPTION
## Summary
- use the decoded provisioning profile name when exporting the archive to keep Fastlane in sync with the CI profile

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4223ef30833391abf6ae49fa6a13)