### PR TITLE
Update provisioning profile specifier

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -239,7 +239,7 @@ platform :ios do
       export_method: "app-store",
       export_options: {
         provisioningProfiles: {
-          app_identifier => app_identifier + " AppStore"
+          app_identifier => profile_name
         }
       },
       build_path: "./builds",

--- a/ios/shaniDms22.xcodeproj/project.pbxproj
+++ b/ios/shaniDms22.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
+                            PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/shaniDms22.app/shaniDms22";
 			};
 			name = Release;
@@ -541,8 +541,8 @@
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.shanidms22;
 				PRODUCT_NAME = shaniDms22;
 				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore";
+                            PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
+                            "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore CI";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
## Summary
- point the manual signing configuration at the CI provisioning profile name so Xcode looks for the correct profile during archives

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4223ef30833391abf6ae49fa6a13)