### PR TITLE
Use Apple Distribution identity for release build

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -104,6 +104,8 @@ def configure_signing_for_ci
   )
 
   decode_secret_to(path: provisioning_profile_path, variable: "APPLE_PROVISIONING_PROFILE")
+
+  install_provisioning_profile(path: provisioning_profile_path)
 end
 
 def configure_signing_for_local
@@ -239,7 +241,7 @@ platform :ios do
       export_method: "app-store",
       export_options: {
         provisioningProfiles: {
-          app_identifier => app_identifier + " AppStore"
+          app_identifier => profile_name
         }
       },
       build_path: "./builds",

--- a/ios/shaniDms22.xcodeproj/project.pbxproj
+++ b/ios/shaniDms22.xcodeproj/project.pbxproj
@@ -475,8 +475,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
+                                PROVISIONING_PROFILE = "";
+                                PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/shaniDms22.app/shaniDms22";
 			};
 			name = Release;
@@ -520,8 +520,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 62;
 				DEVELOPMENT_TEAM = 8KHU9V3DTQ;
@@ -540,9 +540,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.shanidms22;
 				PRODUCT_NAME = shaniDms22;
-				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore";
+                                PROVISIONING_PROFILE = "";
+                                PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
+                                "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore CI";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
## Summary
- update the Release build configuration to use the Apple Distribution signing identity so it matches the CI certificate

## Testing
- not run (requires CI signing secrets)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4223ef30833391abf6ae49fa6a13)