### PR TITLE
Fix code signing identity selection indentation

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -215,11 +215,15 @@ def enforce_code_sign_identities(project_path:, debug_identity:, release_identit
 
   config_sets = project.targets.map(&:build_configurations) + [project.build_configurations]
   config_sets.flatten.each do |config|
-    desired_identity = case config.name
-      when "Debug" then debug_identity
-      when "Release" then release_identity
-      else next
-    end
+    desired_identity =
+      case config.name
+      when "Debug"
+        debug_identity
+      when "Release"
+        release_identity
+      end
+
+    next unless desired_identity
 
     changed |= assign_identity(config, desired_identity)
   end


### PR DESCRIPTION
## Summary
- reformat the case expression that selects the desired code signing identity
- ensure non-Debug/Release configurations are skipped before assigning identities

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef3fd5bc48333a592fd6cfbe77ebc)