### PR TITLE
Use macOS latest runner for iOS beta workflow

### DIFF
--- a/.github/workflows/ios-beta.yml
+++ b/.github/workflows/ios-beta.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   beta:
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       NODE_OPTIONS: --max_old_space_size=4096
       APPLE_PROVISIONING_PROFILE: ${{ vars.APPLE_PROVISIONING_PROFILE || secrets.APPLE_PROVISIONING_PROFILE }}


### PR DESCRIPTION
## Summary
- update the iOS beta GitHub Actions workflow to run on macos-latest instead of the retired macos-13 image

## Testing
- not run (CI workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bfc82f918833392746049d98b52fc)