### PR TITLE
Fix iOS provisioning profile mapping and bundler setup

### DIFF
--- a/.github/workflows/ios-beta.yml
+++ b/.github/workflows/ios-beta.yml
@@ -12,6 +12,7 @@ jobs:
   beta:
     runs-on: macos-latest
     env:
+      BUNDLE_GEMFILE: ios/Gemfile
       NODE_OPTIONS: --max_old_space_size=4096
       APPLE_PROVISIONING_PROFILE: ${{ vars.APPLE_PROVISIONING_PROFILE || secrets.APPLE_PROVISIONING_PROFILE }}
       APPLE_CERTIFICATE_P12: ${{ vars.APPLE_CERTIFICATE_P12 || secrets.APPLE_CERTIFICATE_P12 }}
@@ -43,12 +44,5 @@ jobs:
       - name: Install CocoaPods dependencies
         run: bundle exec pod install --project-directory=ios
 
-      - name: Install fastlane dependencies
-        run: bundle install
-        env:
-          BUNDLE_GEMFILE: ios/Gemfile
-
       - name: Run fastlane
-        env:
-          BUNDLE_GEMFILE: ios/Gemfile
         run: bundle exec fastlane ios ${{ github.event.inputs.lane || 'beta' }}

--- a/ios/shaniDms22.xcodeproj/project.pbxproj
+++ b/ios/shaniDms22.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-                            PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
+				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/shaniDms22.app/shaniDms22";
 			};
 			name = Release;
@@ -543,8 +543,8 @@
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.shanidms22;
 				PRODUCT_NAME = shaniDms22;
 				PROVISIONING_PROFILE = "462f3fc8-ea3b-431f-a47a-bce6ed05934b";
-                            PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore CI";
-                            "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore CI";
+				PROVISIONING_PROFILE_SPECIFIER = "com.shanidms22 AppStore";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "com.shanidms22 AppStore";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
## Summary
- align release provisioning profile specifiers with the installed App Store profile name
- ensure the iOS CI workflow uses the ios Gemfile for bundler commands and remove the redundant install step

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0a24c9748333b07aa473db32b71a)